### PR TITLE
CMakeLists: Declare that there is no compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(Qtilitools
     VERSION 0.1.1
+    LANGUAGES NONE
 )
 string(TOLOWER ${PROJECT_NAME} PROJECT_ID)
 


### PR DESCRIPTION
As there is no compilation going on in this project, declaring so would be a good idea for some distros' tooling.